### PR TITLE
mempool counter offset filter by status

### DIFF
--- a/src/pytezos/context/impl.py
+++ b/src/pytezos/context/impl.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from itertools import chain
 from typing import Optional, Tuple
 
 from pytezos.context.abstract import AbstractContext, get_originated_address  # type: ignore
@@ -124,14 +125,13 @@ class ExecutionContext(AbstractContext):
         key_hash = self.key.public_key_hash()
         mempool = self.shell.mempool.pending_operations()
 
-        for operations in mempool.values():
-            for operation in operations:
-                if isinstance(operation, list):
-                    operation = operation[1]
-                for content in operation.get('contents', []):
-                    if content.get('source') == key_hash:
-                        logger.debug("pending transaction in mempool: %s", content)
-                        counter_offset += 1
+        for operation in chain(mempool.get('applied', []), mempool.get('unprocessed', []):
+            if isinstance(operation, list):
+                operation = operation[1]
+            for content in operation.get('contents', []):
+                if content.get('source') == key_hash:
+                    logger.debug("pending transaction in mempool: %s", content)
+                    counter_offset += 1
 
         logger.debug("counter offset: %s", counter_offset)
         return counter_offset


### PR DESCRIPTION
get_counter_offset is used to determine the counter for transactions being submitted, to accommodate transactions that are in the memory pool.  However the current version will count transactions that have been refused, and failed validation.  This transactions shouldn't be used to calculate the offset, only `applied` and `unprocessed` might result in incrementing the counter for the account.  Impact of this bug is that, when a transaction is refused for an account, subsequent transaction submissions will result in calculation of an invalid counter and rejection of the transaction.